### PR TITLE
log basic evaluation metrics to wandb

### DIFF
--- a/server/handle_request.py
+++ b/server/handle_request.py
@@ -10,11 +10,11 @@ def handle_request(
         max_length: int = 50,
 ) -> str:
     """Generate text from the given model and text."""
-    prediction_result = handle_request_raw(model_id=model_id, text=text,username=username,session_id=session_id,max_length=50)
-    text = prediction_result.get()
-    prediction_result.add_data(get_analysis(text))
+    prediction_result = handle_request_raw(model_id=model_id, text=text, username=username,session_id=session_id,max_length=50)
+    response = prediction_result.get()
+    prediction_result.add_data(get_analysis(response))
     prediction_result.log()
-    return text
+    return response
 
 @monitor(False)
 def handle_request_raw(

--- a/server/handle_request.py
+++ b/server/handle_request.py
@@ -1,8 +1,23 @@
 from mon_sdk import monitor
 from model_provider import multi_model
+from text_analysis import get_analysis
 
-@monitor()
 def handle_request(
+        model_id: str,
+        text: str,
+        username: str,
+        session_id: str,
+        max_length: int = 50,
+) -> str:
+    """Generate text from the given model and text."""
+    prediction_result = handle_request_raw(model_id=model_id, text=text,username=username,session_id=session_id,max_length=50)
+    text = prediction_result.get()
+    prediction_result.add_data(get_analysis(text))
+    prediction_result.log()
+    return text
+
+@monitor(False)
+def handle_request_raw(
         model_id: str,
         text: str,
         username: str,

--- a/server/mon_sdk.py
+++ b/server/mon_sdk.py
@@ -9,27 +9,27 @@ from evaluate import load
 
 # metrics we may care about: perplexity, word_count, toxicity
 def perplexity(text_list):
-  perplexity= load("perplexity",  module_type= "measurement")
-  results = perplexity.compute(data=text_list, model_id='gpt2')
-  return results["perplexities"]
+    perplexity= load("perplexity",  module_type= "measurement")
+    results = perplexity.compute(data=text_list, model_id='gpt2')
+    return results["perplexities"]
 
 def word_count(text_list):
-  if len(text_piece) < 2:
-    return 0, 0
-  wc = load("word_count", module_type="measurement")
-  res = wc.compute(data=text_list)
-  count = res["total_word_count"]
-  unique =  res["unique_words"]
-  try:
-    fraq_unique = float(unique) / float(count)
-  except:
-    fraq_unique = 0
+    if len(text_piece) < 2:
+        return 0, 0
+    wc = load("word_count", module_type="measurement")
+    res = wc.compute(data=text_list)
+    count = res["total_word_count"]
+    unique =  res["unique_words"]
+    try:
+        fraq_unique = float(unique) / float(count)
+    except:
+        fraq_unique = 0
   return count, fraq_unique
 
 def toxicity(text_list):
-  tox = load("toxicity", module_type="measurement")
-  results = tox.compute(predictions=text_list)
-  return results["toxicity"]
+    tox = load("toxicity", module_type="measurement")
+    results = tox.compute(predictions=text_list)
+    return results["toxicity"]
 
 @dataclasses.dataclass
 class PredictionRecord:

--- a/server/mon_sdk.py
+++ b/server/mon_sdk.py
@@ -14,7 +14,7 @@ def perplexity(text_list):
     return results["perplexities"]
 
 def word_count(text_list):
-    if len(text_piece) < 2:
+    if len(text_list[0]) < 2:
         return 0, 0
     wc = load("word_count", module_type="measurement")
     res = wc.compute(data=text_list)
@@ -24,7 +24,7 @@ def word_count(text_list):
         fraq_unique = float(unique) / float(count)
     except:
         fraq_unique = 0
-  return count, fraq_unique
+    return count, fraq_unique
 
 def toxicity(text_list):
     tox = load("toxicity", module_type="measurement")
@@ -50,19 +50,17 @@ class PredictionRecord:
     def log(self, compute_eval_metrics=True):
         if compute_eval_metrics:
             pred = [self._output]
-            tox = toxicity(pred)
-            perp = perplexity(pred)
-            wc, uniq = word_count(pred)
+            total_words, fraction_unique = word_count(pred)
             record = {
                 "prediction_id": self._prediction_id,
                 "latency": self._latency,
                 **self._inputs,
                 # "inputs": self._inputs,
                 "prediction": self._output,
-                "word_count" : wc,
-                "unique" : uniq,
-                "toxicity" : tox,
-                "perplexity" : perp,
+                "word_count" : total_words,
+                "unique" : fraction_unique,
+                "toxicity" : toxicity(pred),
+                "perplexity" : perplexity(pred),
                 **self._additional_data,
             }
             print("record", record)

--- a/server/mon_sdk.py
+++ b/server/mon_sdk.py
@@ -5,31 +5,6 @@ import typing
 import wandb
 import datetime
 
-from evaluate import load
-
-# metrics we may care about: perplexity, word_count, toxicity
-def perplexity(text_list):
-    perplexity= load("perplexity",  module_type= "measurement")
-    results = perplexity.compute(data=text_list, model_id='gpt2')
-    return results["perplexities"]
-
-def word_count(text_list):
-    if len(text_piece) < 2:
-        return 0, 0
-    wc = load("word_count", module_type="measurement")
-    res = wc.compute(data=text_list)
-    count = res["total_word_count"]
-    unique =  res["unique_words"]
-    try:
-        fraq_unique = float(unique) / float(count)
-    except:
-        fraq_unique = 0
-  return count, fraq_unique
-
-def toxicity(text_list):
-    tox = load("toxicity", module_type="measurement")
-    results = tox.compute(predictions=text_list)
-    return results["toxicity"]
 
 @dataclasses.dataclass
 class PredictionRecord:
@@ -47,30 +22,8 @@ class PredictionRecord:
     def add_data(self, data: dict) -> None:
         self._additional_data.update(data)
 
-    def log(self, compute_eval_metrics=True):
-        if compute_eval_metrics:
-            pred = [self._output]
-            tox = toxicity(pred)
-            perp = perplexity(pred)
-            wc, uniq = word_count(pred)
-            record = {
-                "prediction_id": self._prediction_id,
-                "latency": self._latency,
-                **self._inputs,
-                # "inputs": self._inputs,
-                "prediction": self._output,
-                "word_count" : wc,
-                "unique" : uniq,
-                "toxicity" : tox,
-                "perplexity" : perp,
-                **self._additional_data,
-            }
-            print("record", record)
-            self._wandb_run.log(record)
-
-
-        else:   
-            record = {
+    def log(self):
+        record = {
                 "prediction_id": self._prediction_id,
                 "latency": self._latency,
                 **self._inputs,
@@ -78,8 +31,8 @@ class PredictionRecord:
                 "prediction": self._output,
                 **self._additional_data,
             }
-            print("record", record)
-            self._wandb_run.log(record)
+        print("record", record)
+        self._wandb_run.log(record)
 
 
 def monitor(commit=True, input_preprocessor=None, output_postprocessor=None):

--- a/server/mon_sdk.py
+++ b/server/mon_sdk.py
@@ -21,7 +21,7 @@ class PredictionRecord:
     def add_data(self, data: dict) -> None:
         self._additional_data.update(data)
 
-   def log(self):
+    def log(self):
         record = {
                 "prediction_id": self._prediction_id,
                 "latency": self._latency,

--- a/server/mon_sdk.py
+++ b/server/mon_sdk.py
@@ -5,6 +5,31 @@ import typing
 import wandb
 import datetime
 
+from evaluate import load
+
+# metrics we may care about: perplexity, word_count, toxicity
+def perplexity(text_list):
+  perplexity= load("perplexity",  module_type= "measurement")
+  results = perplexity.compute(data=text_list, model_id='gpt2')
+  return results["perplexities"]
+
+def word_count(text_list):
+  if len(text_piece) < 2:
+    return 0, 0
+  wc = load("word_count", module_type="measurement")
+  res = wc.compute(data=text_list)
+  count = res["total_word_count"]
+  unique =  res["unique_words"]
+  try:
+    fraq_unique = float(unique) / float(count)
+  except:
+    fraq_unique = 0
+  return count, fraq_unique
+
+def toxicity(text_list):
+  tox = load("toxicity", module_type="measurement")
+  results = tox.compute(predictions=text_list)
+  return results["toxicity"]
 
 @dataclasses.dataclass
 class PredictionRecord:
@@ -22,8 +47,30 @@ class PredictionRecord:
     def add_data(self, data: dict) -> None:
         self._additional_data.update(data)
 
-    def log(self):
-        record = {
+    def log(self, compute_eval_metrics=True):
+        if compute_eval_metrics:
+            pred = [self._output]
+            tox = toxicity(pred)
+            perp = perplexity(pred)
+            wc, uniq = word_count(pred)
+            record = {
+                "prediction_id": self._prediction_id,
+                "latency": self._latency,
+                **self._inputs,
+                # "inputs": self._inputs,
+                "prediction": self._output,
+                "word_count" : wc,
+                "unique" : uniq,
+                "toxicity" : tox,
+                "perplexity" : perp,
+                **self._additional_data,
+            }
+            print("record", record)
+            self._wandb_run.log(record)
+
+
+        else:   
+            record = {
                 "prediction_id": self._prediction_id,
                 "latency": self._latency,
                 **self._inputs,
@@ -31,8 +78,8 @@ class PredictionRecord:
                 "prediction": self._output,
                 **self._additional_data,
             }
-        print("record", record)
-        self._wandb_run.log(record)
+            print("record", record)
+            self._wandb_run.log(record)
 
 
 def monitor(commit=True, input_preprocessor=None, output_postprocessor=None):

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -1,3 +1,4 @@
+evaluate
 flask
 flask_cors
 transformers

--- a/server/text_analysis.py
+++ b/server/text_analysis.py
@@ -1,0 +1,39 @@
+from evaluate import load
+
+def get_analysis(text):
+    pred = [text]
+    tox = toxicity(pred)
+    perp = perplexity(pred)
+    wc, uniq = word_count(pred)
+    return {
+        "word_count" : wc,
+        "unique" : uniq,
+        "toxicity" : tox,
+        "perplexity" : perp,
+    }
+
+# metrics we may care about: perplexity, word_count, toxicity
+def perplexity(text_list):
+    perplexity= load("perplexity",  module_type= "measurement")
+    results = perplexity.compute(data=text_list, model_id='gpt2')
+    return results["perplexities"]
+
+def word_count(text_list):
+    if len(text_list) < 2:
+        return 0, 0
+    wc = load("word_count", module_type="measurement")
+    res = wc.compute(data=text_list)
+    count = res["total_word_count"]
+    unique =  res["unique_words"]
+    try:
+        fraq_unique = float(unique) / float(count)
+    except:
+        fraq_unique = 0
+    return count, fraq_unique
+
+def toxicity(text_list):
+    tox = load("toxicity", module_type="measurement")
+    results = tox.compute(predictions=text_list)
+    return results["toxicity"]
+
+

--- a/server/text_analysis.py
+++ b/server/text_analysis.py
@@ -16,7 +16,7 @@ def get_analysis(text):
 def perplexity(text_list):
     perplexity= load("perplexity",  module_type= "measurement")
     results = perplexity.compute(data=text_list, model_id='gpt2')
-    return results["perplexities"]
+    return results["perplexities"][0]
 
 def word_count(text_list):
     # expect input to be a list of length exactly one,
@@ -24,18 +24,19 @@ def word_count(text_list):
     if len(text_list) != 1 or len(text_list[0]) < 1:
         return 0, 0
     wc = load("word_count", module_type="measurement")
-    res = wc.compute(data=text_list)
-    count = res["total_word_count"]
-    unique =  res["unique_words"]
     try:
+        res = wc.compute(data=text_list)
+        count = res["total_word_count"]
+        unique =  res["unique_words"]
         fraq_unique = float(unique) / float(count)
     except:
+        count = 0
         fraq_unique = 0
     return count, fraq_unique
 
 def toxicity(text_list):
     tox = load("toxicity", module_type="measurement")
     results = tox.compute(predictions=text_list)
-    return results["toxicity"]
+    return results["toxicity"][0]
 
 

--- a/server/text_analysis.py
+++ b/server/text_analysis.py
@@ -19,7 +19,9 @@ def perplexity(text_list):
     return results["perplexities"]
 
 def word_count(text_list):
-    if len(text_list) < 2:
+    # expect input to be a list of length exactly one,
+    # and the first element to be a string of length at least one
+    if len(text_list) != 1 or len(text_list[0]) < 1:
         return 0, 0
     wc = load("word_count", module_type="measurement")
     res = wc.compute(data=text_list)


### PR DESCRIPTION
- for each prediction/model output, compute: `"word count" `(total words), `"unique"` (fraction 0-1 of unique words, some models are SUPER redundant), `"perplexity"` (higher is more diverse/creative/less likely, lower is more boring/predictable), and _"toxicity"_ (check if an HF model marks this as offensive, 0-1).
- wrapped in an if clause just for convenience, can probably be a lot faster/more elegant
- ideally we take this out of the blocking loop to return predictions—as a user typing and looking at run history, we generate (prompt, prediction) pairs in the history that DO NOT show up in ghostwrite.ai; I only see a small fraction of the generations.

**Note: new required `evaluate` module from HF required me to `brew install xz` and remake my python env**